### PR TITLE
dev: setup basic regtest environment with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,16 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-## RaspiBlitz Setup
+## Setup
 
 While this prototype will hopefully be available as a packaged version soon, here is how you can set it up and play around with it yourself.
 
-### Prerequisite: RaspiBlitz with JoinMarket
+### Docker (regtest)
+See the [docker regtest setup readme](docker/regtest/readme.md).
+
+### RaspiBlitz Setup
+
+#### Prerequisite: RaspiBlitz with JoinMarket
 
 1. Install [JoininBox](https://github.com/openoms/joininbox) on your [RaspiBlitz](https://github.com/rootzoll/raspiblitz):
 
@@ -52,7 +57,7 @@ For this, you will need JoinMarket [version 0.9.3](https://github.com/JoinMarket
 If needed you can upgrade JoinMarket to the latest commit via the JoininBox menu on your RaspiBlitz: Type `jm` in the command line and select ```UPDATE > ADVANCED > JMCOMMIT```.
 This will install the latest development version from JoinMarket's master branch.
 
-### Prerequisite: JoinMarket API Service
+#### Prerequisite: JoinMarket API Service
 
 2. As the joinmarket user on your RaspiBlitz, generate a self-signed certificate for the JoinMarket API Service as described [here](https://linuxize.com/post/creating-a-self-signed-ssl-certificate/), and put the certificate and the key in the `~/.joinmarket/ssl/` directory.
 

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -1,0 +1,156 @@
+version: "3"
+
+services:
+
+  bitcoind:
+    container_name: jm_regtest_bitcoind
+    restart: unless-stopped
+    image: btcpayserver/bitcoin:22.0-1
+    environment:
+      HIDDENSERVICE_NAME: BTC-P2P,BTC-RPC
+      BTC-P2P_HIDDENSERVICE_VIRTUAL_PORT: 8333
+      BTC-P2P_HIDDENSERVICE_PORT: 39388
+      BTC-RPC_HIDDENSERVICE_VIRTUAL_PORT: 8332
+      BTC-RPC_HIDDENSERVICE_PORT: 43782
+      BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
+      BITCOIN_WALLETDIR: "/walletdata"
+      BITCOIN_EXTRA_ARGS: |
+        rpcport=43782
+        rpcbind=0.0.0.0
+        rpcallowip=0.0.0.0/0
+        port=39388
+        whitelist=0.0.0.0/0
+        maxmempool=500
+        debug=1
+        logips=1
+        networkactive=1
+        dnsseed=0
+        uacomment=tbkdevbitcoindregtest
+        printpriority=1
+        logtimemicros=1
+        zmqpubrawblock=tcp://0.0.0.0:28332
+        zmqpubrawtx=tcp://0.0.0.0:28333
+        zmqpubhashblock=tcp://0.0.0.0:28334
+        # tor
+        dns=1
+        onion=tor:9050
+        torcontrol=tor:9051
+        # do not automatically create tor hidden service
+        listenonion=0
+        # rpcauth (user=regtest; password=regtest)
+        rpcauth=regtest:20b58677979ad9d3cf4b78b1d6e85e44$$2ec3e1e1c00c7c58d7aff1d4bf96e4a984ea1af5d676d862fd0faa857a1d4d7c
+        # rpcauth (user=joinmarket; password=joinmarket)
+        rpcauth=joinmarket:260b4c5b1fbd09d75a4aabf90226282f$$76e170af088d43a588992cdd5e7bae2242b03c33aa672cccfd1fb75f9281299e
+        # rpcauth (user=nbxplorer; password=nbxplorer)
+        rpcauth=nbxplorer:8953867752ed07ca27bc0b1d7a10fa99$$e46553870d4a2c59753bfe453797be070ab4dbd5fdfc2fecdb7862ea0ae6b127
+    expose:
+      - "43782" # RPC
+      - "39388" # P2P
+      - "28332" # ZMQ
+      - "28333" # ZMQ
+      - "28334" # ZMQ
+    volumes:
+      - "bitcoin_datadir:/data"
+      - "bitcoin_wallet_datadir:/walletdata"
+      - "tor_datadir:/home/tor/.tor"
+    depends_on:
+      - tor
+
+  nbxplorer:
+    container_name: jm_regtest_nbxplorer
+    restart: unless-stopped
+    image: nicolasdorier/nbxplorer:2.2.18
+    environment:
+      NBXPLORER_NOAUTH: 1
+      NBXPLORER_CHAINS: "btc"
+      NBXPLORER_BTCRPCURL: http://bitcoind:43782/
+      NBXPLORER_BTCRPCUSER: nbxplorer
+      NBXPLORER_BTCRPCPASSWORD: nbxplorer
+      NBXPLORER_BTCNODEENDPOINT: bitcoind:39388
+      NBXPLORER_NETWORK: ${NBITCOIN_NETWORK:-regtest}
+      NBXPLORER_BIND: 0.0.0.0:32838
+      NBXPLORER_TRIMEVENTS: 10000
+      NBXPLORER_SIGNALFILESDIR: /datadir
+    expose:
+      - "32838"
+    volumes:
+      - "nbxplorer_datadir:/datadir"
+      - "bitcoin_datadir:/root/.bitcoin"
+    depends_on:
+      - bitcoind
+      - tor
+
+  miniircd:
+    container_name: jm_regtest_miniircd
+    restart: unless-stopped
+    image: daxxog/miniircd:latest
+    expose:
+      - 6667
+
+  joinmarket:
+    container_name: jm_regtest_joinmarket
+    build:
+      context: ./dockerfile-deps/joinmarket
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      READY_FILE: /root/.nbxplorer/btc_fully_synched
+      ENSURE_WALLET: 1
+      jm_gaplimit: 2000
+      #jm_network: ${NBITCOIN_NETWORK:-regtest}
+      jm_blockchain_source: regtest
+      jm_network: testnet
+      jm_rpc_host: bitcoind
+      jm_rpc_port: 43782
+      jm_rpc_user: joinmarket
+      jm_rpc_password: joinmarket
+      jm_tor_control_host: tor
+      jm_tor_control_port: 9051
+      jm_onion_socks5_host: tor
+      jm_onion_socks5_port: 9050
+      jm_socks5_host: tor
+      jm_socks5_port: 9050
+    expose:
+      - 8080 # payjoin server
+      - 62601 # obwatch
+      - 27183 # joinmarketd
+      - 28183 # jmwalletd
+    ports:
+      - "62601:62601"
+      - "28183:28183"
+    volumes:
+      - "joinmarket_datadir:/root/.joinmarket"
+      - "nbxplorer_datadir:/root/.nbxplorer"
+      - "tor_datadir:/home/tor/.tor"
+    depends_on:
+      - bitcoind
+      - miniircd
+      - nbxplorer
+      - tor
+
+  tor:
+    container_name: jm_regtest_tor
+    restart: unless-stopped
+    image: btcpayserver/tor:0.4.6.5
+    environment:
+      TOR_PASSWORD: changeme
+      TOR_ADDITIONAL_CONFIG: /usr/local/etc/tor/torrc-2
+      TOR_EXTRA_ARGS: |
+        CookieAuthentication 1
+    expose:
+      - "9050"  # SOCKS
+      - "9051"  # Tor Control
+    volumes:
+      - "tor_datadir:/home/tor/.tor"
+      - "tor_torrcdir:/usr/local/etc/tor"
+      - "tor_servicesdir:/var/lib/tor/hidden_services"
+
+
+volumes:
+  bitcoin_datadir:
+  bitcoin_wallet_datadir:
+  nbxplorer_datadir:
+  joinmarket_datadir:
+  tor_datadir:
+  tor_torrcdir:
+  tor_servicesdir:

--- a/docker/regtest/dockerfile-deps/joinmarket/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/Dockerfile
@@ -1,0 +1,18 @@
+FROM btcpayserver/joinmarket:0.9.3
+
+COPY autostart /root/
+COPY default.cfg "${CONFIG}"
+COPY supervisor-conf/*.conf /etc/supervisor/conf.d/
+
+# generate ssl certificates for jmwalletd
+RUN mkdir -p "${DATADIR}/ssl/" && cd "${DATADIR}/ssl/" && \
+    openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out cert.pem -keyout key.pem \
+    -subj "/C=US/ST=Utah/L=Lehi/O=Your Company, Inc./OU=IT/CN=example.com"
+
+#RUN cd /src && \
+#    . jmvenv/bin/activate && \
+#    pip install -r requirements/testing.txt
+
+# joinmarket daemon on port 27183; jmwalletd on port 28183
+EXPOSE 27183 28183
+ENTRYPOINT  [ "tini", "-g", "--", "./docker-entrypoint.sh" ]

--- a/docker/regtest/dockerfile-deps/joinmarket/autostart
+++ b/docker/regtest/dockerfile-deps/joinmarket/autostart
@@ -1,0 +1,7 @@
+# Remove comments in from of the service you want to automatically restart
+# when the container restart.
+
+ob-watcher
+jmwalletd
+# yg-privacyenhanced
+# yield-generator-basic

--- a/docker/regtest/dockerfile-deps/joinmarket/default.cfg
+++ b/docker/regtest/dockerfile-deps/joinmarket/default.cfg
@@ -1,0 +1,325 @@
+[DAEMON]
+#set to 1 to run the daemon service within this process;
+#set to 0 if the daemon is run separately (using script joinmarketd.py)
+no_daemon = 1
+#port on which daemon serves; note that communication still
+#occurs over this port even if no_daemon = 1
+daemon_port = 27183
+#currently, running the daemon on a remote host is
+#*NOT* supported, so don't change this variable
+daemon_host = localhost
+#by default the client-daemon connection is plaintext, set to 'true' to use TLS;
+#for this, you need to have a valid (self-signed) certificate installed
+use_ssl = false
+
+[BLOCKCHAIN]
+# options: bitcoin-rpc, regtest, bitcoin-rpc-no-history, no-blockchain
+# When using bitcoin-rpc-no-history remember to increase the gap limit to scan for more addresses, try -g 5000
+# Use 'no-blockchain' to run the ob-watcher.py script in scripts/obwatch without current access
+# to Bitcoin Core; note that use of this option for any other purpose is currently unsupported.
+#blockchain_source = bitcoin-rpc
+blockchain_source = regtest
+# options: signet, testnet, mainnet
+# Note: for regtest, use network = testnet
+#network = mainnet
+network = testnet
+rpc_host = localhost
+# default ports are 8332 for mainnet, 18443 for regtest, 18332 for testnet, 38332 for signet
+rpc_port = 8332
+rpc_user = bitcoin
+rpc_password = password
+rpc_wallet_file =
+
+[MESSAGING:server1]
+host = miniircd
+hostid = localhost1
+channel = joinmarket-pit
+port = 6667
+usessl = false
+socks5 = false
+socks5_host = localhost
+socks5_port = 9050
+
+#for tor
+#host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
+#port = 6667
+#usessl = false
+#socks5 = true
+
+[LOGGING]
+# Set the log level for the output to the terminal/console
+# Possible choices: DEBUG / INFO / WARNING / ERROR
+# Log level for the files in the logs-folder will always be DEBUG
+#console_log_level = INFO
+console_log_level = DEBUG
+
+# Use color-coded log messages to help distinguish log levels?:
+color = true
+
+[TIMEOUT]
+maker_timeout_sec = 60
+unconfirm_timeout_sec = 180
+confirm_timeout_hours = 6
+
+[POLICY]
+# Use segwit style wallets and transactions
+# Only set to false for old wallets, Joinmarket is now segwit only.
+segwit = true
+
+# Use native segwit (bech32) wallet. If set to false, p2sh-p2wkh
+# will be used when generating the addresses for this wallet.
+# Notes: 1. The default joinmarket pit is native segwit.
+#        2. You cannot change the type of a pre-existing wallet.
+native = true
+
+# for dust sweeping, try merge_algorithm = gradual
+# for more rapid dust sweeping, try merge_algorithm = greedy
+# for most rapid dust sweeping, try merge_algorithm = greediest
+# but don't forget to bump your miner fees!
+merge_algorithm = default
+
+# The fee estimate is based on a projection of how many satoshis
+# per kB are needed to get in one of the next N blocks, N set here
+# as the value of 'tx_fees'. This cost estimate is high if you set
+# N=1, so we choose 3 for a more reasonable figure, as our default.
+# You can also set your own fee/kb: any number higher than 1000 will
+# be interpreted as the fee in satoshi per kB that you wish to use
+# example: N=30000 will use 30000 sat/kB as a fee, while N=5
+# will use the estimate from your selected blockchain source
+tx_fees = 3
+
+# Transaction fee rate variance factor, 0.2 means 20% variation around
+# any manually chosen values, so if you set tx_fees=10000 and
+# tx_fees_factor=0.2, it might use any value between 8000 and 12000 for
+# your transactions.
+tx_fees_factor = 0.2
+
+# For users getting transaction fee estimates over an API,
+# place a sanity check limit on the satoshis-per-kB to be paid.
+# This limit is also applied to users using Core, even though
+# Core has its own sanity check limit, which is currently
+# 1,000,000 satoshis.
+absurd_fee_per_kb = 350000
+
+# In decimal, the maximum allowable change either lower or
+# higher, that the fee rate used for coinjoin sweeps is
+# allowed to be.
+# (note: coinjoin sweeps *must estimate* fee rates;
+# they cannot be exact due to the lack of change output.)
+#
+# Example: max_sweep_fee_change = 0.4, with tx_fees = 10000,
+# means actual fee rate achieved in the sweep can be as low
+# as 6000 sats/kilo-vbyte up to 14000 sats/kilo-vbyte.
+#
+# If this is not achieved, the transaction is aborted. For tumbler,
+# it will then be retried until successful.
+# WARNING: too-strict setting may result in using up a lot
+# of PoDLE commitments, hence the default 0.8 (80%).
+max_sweep_fee_change = 0.8
+
+# Maximum absolute coinjoin fee in satoshi to pay to a single
+# market maker for a transaction. Both the limits given in
+# max_cj_fee_abs and max_cj_fee_rel must be exceeded in order
+# to not consider a certain offer.
+#max_cj_fee_abs = x
+
+# Maximum relative coinjoin fee, in fractions of the coinjoin value
+# e.g. if your coinjoin amount is 2 btc (200000000 satoshi) and
+# max_cj_fee_rel = 0.001 (0.1%), the maximum fee allowed would
+# be 0.002 btc (200000 satoshi)
+#max_cj_fee_rel = x
+
+# the range of confirmations passed to the `listunspent` bitcoind RPC call
+# 1st value is the inclusive minimum, defaults to one confirmation
+# 2nd value is the exclusive maximum, defaults to most-positive-bignum (Google Me!)
+# leaving it unset or empty defers to bitcoind's default values, ie [1, 9999999]
+#listunspent_args = []
+# that's what you should do, unless you have a specific reason, eg:
+#  !!! WARNING !!! CONFIGURING THIS WHILE TAKING LIQUIDITY FROM
+#  !!! WARNING !!! THE PUBLIC ORDERBOOK LEAKS YOUR INPUT MERGES
+#  spend from unconfirmed transactions:  listunspent_args = [0]
+# display only unconfirmed transactions: listunspent_args = [0, 1]
+# defend against small reorganizations:  listunspent_args = [3]
+#   who is at risk of reorganization?:   listunspent_args = [0, 2]
+# NB: using 0 for the 1st value with scripts other than wallet-tool could cause
+# spends from unconfirmed inputs, which may then get malleated or double-spent!
+# other counterparties are likely to reject unconfirmed inputs... don't do it.
+
+# tx_broadcast: options: self, random-peer, not-self.
+#
+# self = broadcast transaction with your own bitcoin node.
+#
+# random-peer = everyone who took part in the coinjoin has a chance of broadcasting
+# note: if your counterparties do not support it, you will fall back
+# to broadcasting via your own node.
+#
+# not-self = never broadcast with your own bitcoin node.
+# note: in this case if your counterparties do not broadcast for you, you
+# will have to broadcast the tx manually (you can take the tx hex from the log
+# or terminal) via some other channel. It is not recommended to choose this
+# option when running schedules/tumbler.
+
+tx_broadcast = random-peer
+
+# If makers do not respond while creating a coinjoin transaction,
+# the non-responding ones will be ignored. This is the minimum
+# amount of makers which we are content with for the coinjoin to
+# succeed. Less makers means that the whole process will restart
+# after a timeout.
+minimum_makers = 4
+
+# Threshold number of satoshis below which an incoming utxo
+# to a reused address in the wallet will be AUTOMATICALLY frozen.
+# This avoids forced address reuse attacks; see:
+# https://en.bitcoin.it/wiki/Privacy#Forced_address_reuse
+#
+# The default is to ALWAYS freeze a utxo to an already used address,
+# whatever the value of it, and this is set with the value -1.
+max_sats_freeze_reuse = -1
+
+# Interest rate used when calculating the value of fidelity bonds created
+# by locking bitcoins in timelocked addresses
+# See also:
+# https://gist.github.com/chris-belcher/87ebbcbb639686057a389acb9ab3e25b#determining-interest-rate-r
+# Set as a real number, i.e. 1 = 100% and 0.01 = 1%
+interest_rate = 0.015
+
+# Some makers run their bots to mix their funds not just to earn money
+# So to improve privacy very slightly takers dont always choose a maker based
+# on his fidelity bond but allow a certain small percentage to be chosen completely
+# randomly without taking into account fidelity bonds
+# This parameter sets how many makers on average will be chosen regardless of bonds
+# A real number, i.e. 1 = 100%, 0.125 = 1/8 = 1 in every 8 makers on average will be bondless
+bondless_makers_allowance = 0.125
+
+##############################
+#THE FOLLOWING SETTINGS ARE REQUIRED TO DEFEND AGAINST SNOOPERS.
+#DON'T ALTER THEM UNLESS YOU UNDERSTAND THE IMPLICATIONS.
+##############################
+
+# number of retries allowed for a specific utxo, to prevent DOS/snooping.
+# Lower settings make snooping more expensive, but also prevent honest users
+# from retrying if an error occurs.
+taker_utxo_retries = 3
+
+# number of confirmations required for the commitment utxo mentioned above.
+# this effectively rate-limits a snooper.
+taker_utxo_age = 5
+
+# percentage of coinjoin amount that the commitment utxo must have
+# as a minimum BTC amount. Thus 20 means a 1BTC coinjoin requires the
+# utxo to be at least 0.2 btc.
+taker_utxo_amtpercent = 20
+
+#Set to 1 to accept broadcast PoDLE commitments from other bots, and
+#add them to your blacklist (only relevant for Makers).
+#There is no way to spoof these values, so the only "risk" is that
+#someone fills your blacklist file with a lot of data.
+accept_commitment_broadcasts = 1
+
+#Location of your commitments.json file (stores commitments you've used
+#and those you want to use in future), relative to the scripts directory.
+commit_file_location = cmtdata/commitments.json
+
+##############################
+# END OF ANTI-SNOOPING SETTINGS
+##############################
+
+[PAYJOIN]
+# for the majority of situations, the defaults
+# need not be altered - they will ensure you don't pay
+# a significantly higher fee.
+# MODIFICATION OF THESE SETTINGS IS DISADVISED.
+
+# Payjoin protocol version; currently only '1' is supported.
+payjoin_version = 1
+
+# servers can change their destination address by default (0).
+# if '1', they cannot. Note that servers can explicitly request
+# that this is activated, in which case we respect that choice.
+disable_output_substitution = 0
+
+# "default" here indicates that we will allow the receiver to
+# increase the fee we pay by:
+# 1.2 * (our_fee_rate_per_vbyte * vsize_of_our_input_type)
+# (see https://github.com/bitcoin/bips/blob/master/bip-0078.mediawiki#span_idfeeoutputspanFee_output)
+# (and 1.2 to give breathing room)
+# which indicates we are allowing roughly one extra input's fee.
+# If it is instead set to an integer, then that many satoshis are allowed.
+# Additionally, note that we will also set the parameter additionafeeoutputindex
+# to that of our change output, unless there is none in which case this is disabled.
+max_additional_fee_contribution = default
+
+# this is the minimum satoshis per vbyte we allow in the payjoin
+# transaction; note it is decimal, not integer.
+min_fee_rate = 1.1
+
+# for payjoins as sender (i.e. client) to hidden service endpoints,
+# the socks5 configuration:
+onion_socks5_host = localhost
+onion_socks5_port = 9050
+
+# for payjoin onion service creation:
+# the tor control configuration:
+tor_control_host = localhost
+# or, to use a UNIX socket
+# control_host = unix:/var/run/tor/control
+tor_control_port = 9051
+# the host/port actually serving the hidden service
+# (note the *virtual port*, that the client uses,
+# is hardcoded to 80):
+onion_serving_host = 127.0.0.1
+onion_serving_port = 8080
+
+# in some exceptional case the HS may be SSL configured,
+# this feature is not yet implemented in code, but here for the
+# future:
+hidden_service_ssl = false
+
+[YIELDGENERATOR]
+# [string, 'reloffer' or 'absoffer'], which fee type to actually use
+ordertype = reloffer
+
+# [satoshis, any integer] / absolute offer fee you wish to receive for coinjoins (cj)
+cjfee_a = 500
+
+# [fraction, any str between 0-1] / relative offer fee you wish to receive based on a cj's amount
+cjfee_r = 0.00002
+
+# [fraction, 0-1] / variance around the average fee. Ex: 200 fee, 0.2 var = fee is btw 160-240
+cjfee_factor = 0.1
+
+# [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
+# (note: this will soon be deprecated; leave at zero)
+txfee_contribution = 0
+
+# [fraction, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
+txfee_contribution_factor = 0.3
+
+# [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
+minsize = 100000
+
+# [fraction, 0-1] / variance around all offer sizes. Ex: 500k minsize, 0.1 var = 450k-550k
+size_factor = 0.1
+
+gaplimit = 6
+
+[SNICKER]
+
+# any other value than 'true' will be treated as False,
+# and no SNICKER actions will be enabled in that case:
+enabled = false
+
+# in satoshis, we require any SNICKER to pay us at least
+# this much (can be negative), otherwise we will refuse
+# to sign it:
+lowest_net_gain = 0
+
+# comma separated list of servers (if port is omitted as :port, it
+# is assumed to be 80) which we will poll against (all, in sequence); note
+# that they are allowed to be *.onion or cleartext servers, and no
+# scheme (http(s) etc) needs to be added to the start.
+servers = cn5lfwvrswicuxn3gjsxoved6l2gu5hdvwy5l3ev7kg6j7lbji2k7hqd.onion,
+
+# how many minutes between each polling event to each server above:
+polling_interval_minutes = 60

--- a/docker/regtest/dockerfile-deps/joinmarket/supervisor-conf/jmwalletd.conf
+++ b/docker/regtest/dockerfile-deps/joinmarket/supervisor-conf/jmwalletd.conf
@@ -1,0 +1,10 @@
+[program:jmwalletd]
+directory=/src/scripts
+command=exec-wrapper.sh python jmwalletd.py
+autostart=false
+stdout_logfile=/root/.joinmarket/logs/jmwalletd_stdout.log
+stdout_logfile_maxbytes=5MB
+stdout_logfile_backups=0
+stderr_logfile=/root/.joinmarket/logs/jmwalletd_stderr.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=0

--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -1,0 +1,28 @@
+
+# Docker setup for running joinmarket in regtest mode
+
+
+## Run
+Go to the docker directory (`cd docker/regtest`) and execute:
+
+```shell
+docker-compose up
+```
+
+(run `docker-compose down -v` before to start with a fresh setup)
+
+## Stop
+```shell
+docker-compose down
+```
+
+# Troubleshooting
+1. Joinmarket won't start in initial run
+
+Solution: Somehow nbxplorer does not notify joinmarket that the chain is fully synced in the initial run.
+Just shutdown all containers with `docker-compose down` wait for it to finish and run `docker-compose up` again (`docker-compose restart` did _not_ work sometimes!). 
+Now you should see joinmarket coming up and see something like the following output:
+```log
+joinmarket_1  | 2009-01-03 00:02:44,907 INFO success: jmwalletd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+joinmarket_1  | 2009-01-03 00:02:44,907 INFO success: ob-watcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+```


### PR DESCRIPTION
Adds a basic joinmarket setup in regtest mode for local development.
Hope this slightly improves the dev experience.

Most containers are based off of images provided by [`btcpayserver`](https://github.com/btcpayserver/dockerfile-deps) (except `miniircd`). joinmarket container setup is adapted a little bit to also start `jmwalletd` by default.

Unfortunately, the setup has the flaw that you have to start it twice for it to work properly, see the "Troubleshooting" section in the readme (`docker/regtest/readme.md`)

Still TODO: 
- does not start the yieldgenerator yet
- some polishing (e.g. maybe `debug=rpc` for bitcoind is better (?), start a second jm instance, auto-fund regtest wallet, etc.)

## Included containers
- joinmarket (slightly adapted from `btcpayserver/joinmarket:0.9.3`)
  - automatically start "jmwalletd" on port 28183
  - automatically start "ob-watcher" on port 62601
- bitcoind (`btcpayserver/bitcoin:22.0-1`)
  - with debug options enabled (to easily see all rpc requests by user "joinmarket")
- nbxplorer (`nicolasdorier/nbxplorer:2.2.18`)
  - notify joinmarket when chain is fully synced
- tor (`btcpayserver/tor:0.4.6.5`)
- miniircd (`daxxog/miniircd:latest`)

## Run
Go to the docker directory (`cd docker/regtest`) and execute:

```shell
docker-compose up
```

(run `docker-compose down -v` before to start with a fresh setup)

## Stop
```shell
docker-compose down
```